### PR TITLE
Prevent authorization header from being set

### DIFF
--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -282,7 +282,10 @@ namespace Private {
     let authenticated = false;
     if (settings.token) {
       authenticated = true;
-      request.headers.append('Authorization', `token ${settings.token}`);
+      
+      // don't set the token as the authorization header as it intereferes
+      // with custom authorization header (bearer token)
+      //request.headers.append('Authorization', `token ${settings.token}`);
     }
     if (typeof document !== 'undefined' && document?.cookie) {
       const xsrfToken = getCookie('_xsrf');


### PR DESCRIPTION
Placeholder change to prevent an authorization header from being written because we're passing in our own (bearer token to work with Azure ML computes).